### PR TITLE
Enable this to be built and distributed using modern Python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gitchangelog==2.3.0
-Sphinx==1.4.5
+# gitchangelog==2.3.0
+Sphinx==7.2.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,15 @@
 [metadata]
 name = grapefruit
-version = 0.1a4
-summary = A module to manipulate color information easily.
-description-file =
-  README.rst
-requires-dist =
+version = 0.1a5
+description = A module to manipulate color information easily.
+long_description = file: README.rst
 
 ## sdist info
 author = Xavier Basty
 author_email = xbasty@gmail.com
-home_page = https://github.com/xav/Grapefruit/
+url = https://github.com/xav/Grapefruit/
 keywords = color, colour
-classifier =
+classifiers =
   Programming Language :: Python
   Development Status :: 3 - Alpha
   Intended Audience :: Developers
@@ -20,13 +18,13 @@ classifier =
   Topic :: Software Development :: Libraries :: Python Modules
   Topic :: Multimedia :: Graphics
 
-[files]
-modules = grapefruit
-resources =
-  README.rst = {doc}
-  doc/* = {doc}
-extra_files =
-  setup.py
+[options]
+py_modules = grapefruit
+
+[options.package_data]
+grapefruit =
+  *.rst
+  doc/*
 
 [nosetests]
 verbosity = 3

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distribute_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup
+from setuptools import setup
 
 setup(
-    setup_requires=['d2to1'],
     extras_require={'test': ['nose', ]},
-    d2to1=True
 )


### PR DESCRIPTION
Remove dependency on d2to1 which is deprecated, and rather user standard setuptools
Remove dependency on gitchangelog which also requires d2to1
Bump version to 0.1a5

I'm aware that there may be a desire to approach this differently but just wanted to send this off as these changes made me able to use Grapefruit on Python 3.11...